### PR TITLE
fix(config): Link vite-config-site into storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,11 @@ const config: StorybookConfig = {
   stories: ['../src/kapwa/**/*.stories.tsx'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: 'vite.config-site.ts',
+      },
+    },
   },
   addons: [
     '@storybook/addon-links',

--- a/package.json
+++ b/package.json
@@ -116,43 +116,43 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs"
     },
     "./utils": {
       "import": "./dist/utils.js",
-      "require": "./dist/utils.cjs",
-      "types": "./dist/utils.d.ts"
+      "types": "./dist/utils.d.ts",
+      "require": "./dist/utils.cjs"
     },
     "./banner": {
       "import": "./dist/banner/index.tsx.js",
-      "require": "./dist/banner/index.tsx.cjs",
-      "types": "./dist/banner/index.d.ts"
+      "types": "./dist/banner/index.d.ts",
+      "require": "./dist/banner/index.tsx.cjs"
     },
     "./button": {
       "import": "./dist/button/index.tsx.js",
-      "require": "./dist/button/index.tsx.cjs",
-      "types": "./dist/button/index.d.ts"
+      "types": "./dist/button/index.d.ts",
+      "require": "./dist/button/index.tsx.cjs"
     },
     "./button/hooks": {
       "import": "./dist/button/hooks/index.ts.js",
-      "require": "./dist/button/hooks/index.ts.cjs",
-      "types": "./dist/button/hooks/index.d.ts"
+      "types": "./dist/button/hooks/index.d.ts",
+      "require": "./dist/button/hooks/index.ts.cjs"
     },
     "./card": {
       "import": "./dist/card/index.tsx.js",
-      "require": "./dist/card/index.tsx.cjs",
-      "types": "./dist/card/index.d.ts"
+      "types": "./dist/card/index.d.ts",
+      "require": "./dist/card/index.tsx.cjs"
     },
     "./input": {
       "import": "./dist/input/index.tsx.js",
-      "require": "./dist/input/index.tsx.cjs",
-      "types": "./dist/input/index.d.ts"
+      "types": "./dist/input/index.d.ts",
+      "require": "./dist/input/index.tsx.cjs"
     },
     "./label": {
       "import": "./dist/label/index.tsx.js",
-      "require": "./dist/label/index.tsx.cjs",
-      "types": "./dist/label/index.d.ts"
+      "types": "./dist/label/index.d.ts",
+      "require": "./dist/label/index.tsx.cjs"
     }
   },
   "typesVersions": {

--- a/vite.config-site.ts
+++ b/vite.config-site.ts
@@ -20,5 +20,8 @@ export default defineConfig({
       '@kapwa': path.resolve(__dirname, './src/kapwa'),
     },
   },
+  optimizeDeps: {
+    exclude: ['storybook'],
+  },
   plugins: [react(), tailwindcss()],
 });


### PR DESCRIPTION
**Summary**
Updates storybook config and package.json to clear out warnings within storybook.

**Testing**
```
npm run dev # both client and storybook
npm run start:storybook # just storybook
```


**Other notes**
This pull request introduces configuration improvements for both Storybook and Vite, as well as a minor fix to the `package.json` exports ordering. The main changes focus on better integration between Storybook and Vite, optimizing dependency handling, and ensuring consistent export definitions.

**Storybook and Vite integration:**
* Configured Storybook to use a custom Vite config by specifying `viteConfigPath: 'vite.config-site.ts'` in the Storybook framework options, allowing for more tailored build settings.

**Vite configuration:**
* Updated `vite.config-site.ts` to exclude `storybook` from optimized dependencies, which can help prevent potential build or runtime issues when using Storybook alongside Vite.

**Package export ordering:**
* Adjusted the order of `"require"` and `"types"` fields in the `package.json` exports for several modules, ensuring `"types"` comes before `"require"` for consistency and possibly improved compatibility.