### PR TITLE
feat(package) Adds prepublish step and make library public

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=http://localhost:4873

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bettergov/kapwa",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bettergov/kapwa",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@icons-pack/react-simple-icons": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
   "scripts": {
     "dev": "concurrently -p \"[{name}]\" -n \"CLIENT,STORYBOOK\" -c \"bgBlue.bold,bgMagenta.bold\" \"npm run start:client\" \"npm run start:storybook\"",
     "start:client": "vite --config vite.config-site.ts",
@@ -19,7 +22,7 @@
     "wrangler": "wrangler",
     "preview": "vite preview --config vite.config-site.ts",
     "prepare": "husky",
-    "prepublish": "npm run build-lib"
+    "prepublishOnly": "npm run build-lib"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -117,43 +120,43 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./utils": {
       "import": "./dist/utils.js",
-      "types": "./dist/utils.d.ts",
-      "require": "./dist/utils.cjs"
+      "require": "./dist/utils.cjs",
+      "types": "./dist/utils.d.ts"
     },
     "./banner": {
       "import": "./dist/banner/index.tsx.js",
-      "types": "./dist/banner/index.d.ts",
-      "require": "./dist/banner/index.tsx.cjs"
+      "require": "./dist/banner/index.tsx.cjs",
+      "types": "./dist/banner/index.d.ts"
     },
     "./button": {
       "import": "./dist/button/index.tsx.js",
-      "types": "./dist/button/index.d.ts",
-      "require": "./dist/button/index.tsx.cjs"
+      "require": "./dist/button/index.tsx.cjs",
+      "types": "./dist/button/index.d.ts"
     },
     "./button/hooks": {
       "import": "./dist/button/hooks/index.ts.js",
-      "types": "./dist/button/hooks/index.d.ts",
-      "require": "./dist/button/hooks/index.ts.cjs"
+      "require": "./dist/button/hooks/index.ts.cjs",
+      "types": "./dist/button/hooks/index.d.ts"
     },
     "./card": {
       "import": "./dist/card/index.tsx.js",
-      "types": "./dist/card/index.d.ts",
-      "require": "./dist/card/index.tsx.cjs"
+      "require": "./dist/card/index.tsx.cjs",
+      "types": "./dist/card/index.d.ts"
     },
     "./input": {
       "import": "./dist/input/index.tsx.js",
-      "types": "./dist/input/index.d.ts",
-      "require": "./dist/input/index.tsx.cjs"
+      "require": "./dist/input/index.tsx.cjs",
+      "types": "./dist/input/index.d.ts"
     },
     "./label": {
       "import": "./dist/label/index.tsx.js",
-      "types": "./dist/label/index.d.ts",
-      "require": "./dist/label/index.tsx.cjs"
+      "require": "./dist/label/index.tsx.cjs",
+      "types": "./dist/label/index.d.ts"
     }
   },
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bettergov/kapwa",
-  "private": true,
+  "private": false,
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,7 +18,8 @@
     "format": "prettier --write .",
     "wrangler": "wrangler",
     "preview": "vite preview --config vite.config-site.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublish": "npm run build-lib"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
### Summary
Adds pre-publish step so that the library builds before publish.

### Testing using verdaccio

```
# on a separate terminal
npm install -g verdaccio
verdaccio
```

```
# on a tab w/ kapwa
npm version minor
npm publish
```


### Docs
[verdaccio](https://verdaccio.org/docs/what-is-verdaccio)

### Other Notes 

This pull request updates the project configuration to support publishing the package and local development. The most important changes are in the `package.json` and `.npmrc` files.

**Package publishing and registry configuration:**

* Made the package public by setting `"private": false` in `package.json`, allowing it to be published to a registry.
* Added a `.npmrc` file to set the npm registry to `http://localhost:4873`, which is commonly used for local development and testing with Verdaccio.

**Build and publish workflow improvements:**

* Added a `prepublish` script (`npm run build-lib`) to the `package.json` scripts, ensuring the library is built before publishing.